### PR TITLE
Refactor list_filtered_objects method to include subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started, download the executable from the project's [releases page](https
 
 ### Windows
 
--   Locate the downloaded `Parquetizer.exe` file.
+-   Locate the downloaded `Parquetizer-windows.exe` file.
 -   Double-click the file to run the program.
 
 ### Linux
@@ -29,11 +29,11 @@ To get started, download the executable from the project's [releases page](https
 Execute the following commands in the terminal:
 
 ```bash
-chmod +x Parquetizer     # Make the file executable
-./Parquetizer            # Run the program
+chmod +x Parquetizer-linux      # Make the file executable
+./Parquetizer                   # Run the program
 ```
 
 ### MacOS
 
 -   Open Finder and go to the location where Parquetizer.app is saved.
--   Double-click on Parquetizer.app to start the application.
+-   Double-click on `Parquetizer-macos` to start the application.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "parquetizer"
-version = "0.3.0"
+version = "0.3.1"
 description = "A CLI tool for converting various data formats to Parquet."
 authors = ["TzuH-Hsu <96853116+TzuH-Hsu@users.noreply.github.com>"]
 license = "GPL-3.0"

--- a/src/parquetizer/_source_handler.py
+++ b/src/parquetizer/_source_handler.py
@@ -1,6 +1,5 @@
 # ruff: noqa: PLR0913, FBT001, FBT002
 import logging
-import os
 from abc import ABC, abstractmethod
 from io import BytesIO
 from pathlib import Path
@@ -37,16 +36,15 @@ class Local(SrcHandler):
         self.path = Path(full_path)
 
     def list_filtered_objects(self, extension: str) -> list[str]:
-        """Lists all the objects in the path with the specified extension.
+        """Lists all the objects in the path and its subdirectories with the specified extension.
 
         Args:
-            path (str): The path of the directory.
             extension (str): The extension of the objects.
 
         Returns:
             list[str]: The list of object names.
-        """
-        return [file for file in os.listdir(self.path) if file.endswith(extension)]
+        """  # noqa: E501
+        return [str(file) for file in self.path.rglob(f"*.{extension}")]
 
     def read(self, file: str) -> BytesIO:
         file_path = self.path / file

--- a/src/parquetizer/_source_handler.py
+++ b/src/parquetizer/_source_handler.py
@@ -44,7 +44,7 @@ class Local(SrcHandler):
         Returns:
             list[str]: The list of object names.
         """  # noqa: E501
-        return [str(file) for file in self.path.rglob(f"*.{extension}")]
+        return [str(file) for file in self.path.rglob(f"*{extension}")]
 
     def read(self, file: str) -> BytesIO:
         file_path = self.path / file


### PR DESCRIPTION
This pull request refactors the `list_filtered_objects` method in the `_source_handler.py` file to include subdirectories when listing objects with a specified extension. Additionally, it updates file names and instructions for Windows and MacOS, and updates the version to 0.3.1 in the `pyproject.toml` file.